### PR TITLE
Android build

### DIFF
--- a/cocos/Android.mk
+++ b/cocos/Android.mk
@@ -235,9 +235,11 @@ LOCAL_WHOLE_STATIC_LIBRARIES := cocos2dxandroid_static
 
 # define the macro to compile through support/zip_support/ioapi.c
 LOCAL_CFLAGS   :=  -DUSE_FILE32API
-LOCAL_CPPFLAGS := -Wno-deprecated-declarations -Wno-extern-c-compat
+LOCAL_CPPFLAGS := -Wno-deprecated-declarations
+# -Wno-extern-c-compat
 LOCAL_EXPORT_CFLAGS   := -DUSE_FILE32API
-LOCAL_EXPORT_CPPFLAGS := -Wno-deprecated-declarations -Wno-extern-c-compat
+LOCAL_EXPORT_CPPFLAGS := -Wno-deprecated-declarations
+# -Wno-extern-c-compat
 
 include $(BUILD_STATIC_LIBRARY)
 

--- a/cocos/platform/android/Android.mk
+++ b/cocos/platform/android/Android.mk
@@ -36,8 +36,8 @@ LOCAL_EXPORT_LDLIBS := -lGLESv1_CM \
                        -lz \
                        -landroid
 
-LOCAL_CPPFLAGS := -Wno-extern-c-compat
+# LOCAL_CPPFLAGS := -Wno-extern-c-compat
 
-LOCAL_EXPORT_CPPFLAGS := -Wno-extern-c-compat
+# LOCAL_EXPORT_CPPFLAGS := -Wno-extern-c-compat
 
 include $(BUILD_STATIC_LIBRARY)

--- a/cocos/scripting/lua-bindings/proj.android/Android.mk
+++ b/cocos/scripting/lua-bindings/proj.android/Android.mk
@@ -174,4 +174,4 @@ LOCAL_STATIC_LIBRARIES := cocos2dx_static
 include $(BUILD_STATIC_LIBRARY)
 
 $(call import-module,lua/luajit/prebuilt/android)
-$(call import-module,.)
+# $(call import-module,.)


### PR DESCRIPTION
This is the smallest number of changes required to make cocos2d-x v3 build under the android NDK. This is required for griffin and marvel to build for android.