### PR TITLE
Added stdlib.h to fix malloc/free reference issues on Android.

### DIFF
--- a/cocos/audio/android/AudioDecoder.cpp
+++ b/cocos/audio/android/AudioDecoder.cpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 
 #include <thread>
 #include <chrono>
+#include <stdlib.h>
 
 namespace cocos2d { namespace experimental {
 

--- a/cocos/audio/android/AudioMixerController.cpp
+++ b/cocos/audio/android/AudioMixerController.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "audio/android/Track.h"
 #include "audio/android/OpenSLHelper.h"
 
+#include <stdlib.h>
 #include <algorithm>
 
 namespace cocos2d { namespace experimental {


### PR DESCRIPTION
This fixes errors that occur in the newer versions of the Android NDK. cocos2d-x's master branch has also added these headers in these files in recent versions.