### PR TITLE
Android: Fix EngineController::resume not being called because someti…

### DIFF
--- a/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp
+++ b/cocos/platform/android/jni/Java_org_cocos2dx_lib_Cocos2dxRenderer.cpp
@@ -61,8 +61,8 @@ extern "C" {
             cocos2d::EventCustom foregroundEvent(EVENT_COME_TO_FOREGROUND);
             cocos2d::Director::getInstance()->getEventDispatcher()->dispatchEvent(&foregroundEvent);
 
-            firstTime = false;
         }
+        firstTime = false;
     }
 
     JNIEXPORT void JNICALL Java_org_cocos2dx_lib_Cocos2dxRenderer_nativeInsertText(JNIEnv* env, jobject thiz, jstring text) {


### PR DESCRIPTION
…mes the first nativeOnResume is called before the openGLContext exists, therefore the second resume was actually consumed as though it is the first, causing the game to softlock when it fails to resume.